### PR TITLE
Always parse user agent

### DIFF
--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -180,8 +180,6 @@ function common(facade, settings) {
   const platform = platformFromLibrary(lib) || facade.proxy('context.device.type') || (os && os.toLowerCase()) || lib;
   if (platform) ret.platform = sanitizePlatform(platform);
 
-  // Unbundled integration support
-  if ((lib || '').toString().toLowerCase() === 'analytics.js') {
     // Parse out browser info to match information provided by `amplitude.js`
     const userAgent = facade.userAgent();
     if (userAgent) {
@@ -189,7 +187,8 @@ function common(facade, settings) {
       ret.os_name = parsedUserAgent.browser.name;
       ret.os_version = parsedUserAgent.browser.major;
       ret.device_model = parsedUserAgent.os.name;
-    }
+    ret.device_manufacturer = parsedUserAgent.device.vendor;
+    ret.device_brand = parsedUserAgent.device.model;
   }
 
   ret.user_properties = traits(facade.traits());

--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -5,7 +5,7 @@
 const find = require('obj-case');
 const { parse } = require('locale-string');
 const reject = require('reject');
-const UAParser = require('ua-parser-js');
+const UAParser = require('@amplitude/ua-parser-js');
 const isEmpty = require('lodash/isEmpty');
 const keys = require('lodash/keys');
 
@@ -180,13 +180,13 @@ function common(facade, settings) {
   const platform = platformFromLibrary(lib) || facade.proxy('context.device.type') || (os && os.toLowerCase()) || lib;
   if (platform) ret.platform = sanitizePlatform(platform);
 
-    // Parse out browser info to match information provided by `amplitude.js`
-    const userAgent = facade.userAgent();
-    if (userAgent) {
-      const parsedUserAgent = (new UAParser(userAgent)).getResult();
-      ret.os_name = parsedUserAgent.browser.name;
-      ret.os_version = parsedUserAgent.browser.major;
-      ret.device_model = parsedUserAgent.os.name;
+  // Parse out browser info to match information provided by `amplitude.js`
+  const userAgent = facade.userAgent();
+  if (userAgent) {
+    const parsedUserAgent = (new UAParser(userAgent)).getResult();
+    ret.os_name = parsedUserAgent.browser.name;
+    ret.os_version = parsedUserAgent.browser.major;
+    ret.device_model = parsedUserAgent.os.name;
     ret.device_manufacturer = parsedUserAgent.device.vendor;
     ret.device_brand = parsedUserAgent.device.model;
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@amplitude/ua-parser-js": {
+      "version": "0.7.20",
+      "resolved": "https://registry.npmjs.org/@amplitude/ua-parser-js/-/ua-parser-js-0.7.20.tgz",
+      "integrity": "sha512-bmW++BLt1Hg+4HCExLXP+0Jhgy2eTsEevqkVc5o4yYbgwdP/gV3gEQXzyVrMVlWWNLgph/tFIkf5PVlSpCELEg=="
+    },
     "@babel/code-frame": {
       "version": "7.5.5",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
@@ -2773,8 +2778,9 @@
       "integrity": "sha1-lSpsgcIe/STRPYEdDISYy4YOGVY="
     },
     "ua-parser-js": {
-      "version": "git+https://github.com/amplitude/ua-parser-js.git#fbdb1dc7a6263f7aa9e13750afc54b138fa8ebe1",
-      "from": "git+https://github.com/amplitude/ua-parser-js.git#fbdb1dc"
+      "version": "0.7.20",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.20.tgz",
+      "integrity": "sha512-8OaIKfzL5cpx8eCMAhhvTlft8GYF8b2eQr6JkCyVdrgjcytyOmPCXrqXFcUnhonRpLlh5yxEZVohm6mzaowUOw=="
     },
     "uglify-js": {
       "version": "3.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@segment/integration-amplitude",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2776,11 +2776,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/type-component/-/type-component-0.0.1.tgz",
       "integrity": "sha1-lSpsgcIe/STRPYEdDISYy4YOGVY="
-    },
-    "ua-parser-js": {
-      "version": "0.7.20",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.20.tgz",
-      "integrity": "sha512-8OaIKfzL5cpx8eCMAhhvTlft8GYF8b2eQr6JkCyVdrgjcytyOmPCXrqXFcUnhonRpLlh5yxEZVohm6mzaowUOw=="
     },
     "uglify-js": {
       "version": "3.6.1",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test": "make test"
   },
   "dependencies": {
+    "@amplitude/ua-parser-js": "^0.7.20",
     "locale-string": "^1.0.0",
     "lodash": "^4.17.4",
     "lodash.some": "^4.6.0",
@@ -19,7 +20,6 @@
     "reject": "0.0.1",
     "segmentio-integration": "^5.1.0",
     "to-title-case": "^0.1.5",
-    "ua-parser-js": "git+https://github.com/amplitude/ua-parser-js.git#fbdb1dc",
     "urlencode": "^1.1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@segment/integration-amplitude",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Amplitude server-side integration",
   "author": "Segment <friends@segment.com>",
   "repository": {


### PR DESCRIPTION
- User-agent parsing is no longer tied to the `analytics.js` lib and can be leveraged by any source.
- Updated the user-agent parsing library to Amplitude's latest.
- Added `device_manufacturer` and `device_brand` to the sent payload.

Tested using UA strings from https://deviceatlas.com/blog/list-of-user-agent-strings.